### PR TITLE
Fix occlusion queries affected by antialiasing

### DIFF
--- a/RenderstateManager.h
+++ b/RenderstateManager.h
@@ -117,7 +117,11 @@ class RSManager {
 	void dumpShader(UINT32 hash, const char *directory, LPD3DXBUFFER pBuffer);
 	bool getOverrideShader(UINT32 hash, const char *directory, LPD3DXBUFFER *ppBuffer);
 
-	float areaScale;
+	bool haveOcclusionScale;
+	float occlusionScale;
+
+	void measureOcclusionScale();
+
 private:
     ~RSManager();
 
@@ -128,7 +132,7 @@ public:
 
 	RSManager() : smaa(NULL), fxaa(NULL), ssao(NULL), gauss(NULL), rgbaBuffer1Surf(NULL), rgbaBuffer1Tex(NULL),
 			inited(false), doAA(true), doSsao(true), doDofGauss(true), doHud(true), captureNextFrame(false), capturing(false), hudStarted(false), takeScreenshot(false), hideHud(false),
-			mainRenderTexIndex(0), mainRenderSurfIndex(0), dumpCaptureIndex(0), numKnownTextures(0), foundKnownTextures(0), skippedPresents(0), areaScale(1) {
+			mainRenderTexIndex(0), mainRenderSurfIndex(0), dumpCaptureIndex(0), numKnownTextures(0), foundKnownTextures(0), skippedPresents(0), haveOcclusionScale(false), occlusionScale(1) {
 		#define TEXTURE(_name, _hash) ++numKnownTextures;
 		#include "Textures.def"
 		#undef TEXTURE
@@ -197,5 +201,5 @@ public:
 	HRESULT redirectCreatePixelShader(CONST DWORD *pfunction, IDirect3DPixelShader9 **ppShader);
 	HRESULT redirectCreateVertexShader(CONST DWORD *pfunction, IDirect3DVertexShader9 **ppShader);
 
-	float getAreaScale() const { return areaScale; }
+	float getOcclusionScale() const { return occlusionScale; }
 };

--- a/d3d9query.cpp
+++ b/d3d9query.cpp
@@ -38,9 +38,9 @@ HRESULT APIENTRY hkIDirect3DQuery9::Issue(DWORD dwIssueFlags) {
 
 HRESULT APIENTRY hkIDirect3DQuery9::GetData(void* pData, DWORD dwSize, DWORD dwGetDataFlags) {
 	auto result = m_pD3Dquery->GetData(pData, dwSize, dwGetDataFlags);
-	if (result == D3D_OK) {
+	if (SUCCEEDED(result)) {
 		auto pixelsDrawn = reinterpret_cast<DWORD*>(pData);
-		pixelsDrawn[0] = static_cast<DWORD>(pixelsDrawn[0] / RSManager::get().getAreaScale());
+		pixelsDrawn[0] = static_cast<DWORD>(pixelsDrawn[0] / RSManager::get().getOcclusionScale());
 	}
 	return result;
 }


### PR DESCRIPTION
Occlusion queries might return larger values than expected if
driver-enforced antialiasing is enabled.

This change makes an occlusion query for a square of a known size to
determine what result that should be expected. This is used by the
IDirect3DQuery9 wrapper to scale the result of further queries
appropriately, considering both the rendering resolution and unexpected
multisampling enforced by the driver.